### PR TITLE
[BUGFIX] Fix GenerateRequestTokenListener for FE authentication

### DIFF
--- a/Classes/Events/Listener/GenerateRequestTokenListener.php
+++ b/Classes/Events/Listener/GenerateRequestTokenListener.php
@@ -35,7 +35,7 @@ class GenerateRequestTokenListener
         // wenn oauth cookie => get time from token from cookie
         // wenn request within 5 sec => generate and set token
 
-        $requestToken = RequestToken::create('core/user-auth/be');
+        $requestToken = RequestToken::create('core/user-auth/' . strtolower($event->getUser()->loginType));
         $event->setRequestToken($requestToken);
 
         $request = $event->getRequest();


### PR DESCRIPTION
The event always generated a token for BE logins - but was also executed if an FE login (possibly also without oauth) was executed. This meant that all FE authentication failed. A token for correct scope is now generated based on the `loginType`.